### PR TITLE
Idempotent static routing configuration

### DIFF
--- a/tasks/cloud_vpn/providers/rhel/initiator/configure_routing.yaml
+++ b/tasks/cloud_vpn/providers/rhel/initiator/configure_routing.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Add static routes to responder
-  command: "ip route add {{ cloud_vpn_responder_cidr }} dev {{ cloud_vpn_initiator_tunnel_interface }}"
+  shell: "ip route | grep {{ cloud_vpn_responder_cidr }} || ip route add {{ cloud_vpn_responder_cidr }} dev {{ cloud_vpn_initiator_tunnel_interface }}"
   become: yes
   delegate_to: initiator

--- a/tasks/cloud_vpn/providers/rhel/responder/configure_routing.yaml
+++ b/tasks/cloud_vpn/providers/rhel/responder/configure_routing.yaml
@@ -1,6 +1,6 @@
 ---
 
 - name: Add static routes to initiator
-  command: "ip route add {{ cloud_vpn_initiator_cidr }} dev {{ cloud_vpn_responder_tunnel_interface }}"
+  shell: "ip route | grep {{ cloud_vpn_initiator_cidr }} || ip route add {{ cloud_vpn_initiator_cidr }} dev {{ cloud_vpn_responder_tunnel_interface }}"
   become: yes
   delegate_to: responder


### PR DESCRIPTION
Without this change, the ip route command would fail on subsequent plays
as the routes are already present.

Signed-off-by: Ricardo Carrillo Cruz <ricardo.carrillo.cruz@gmail.com>