### PR TITLE
Get facts after add_host tasks

### DIFF
--- a/tasks/cloud_vpn/providers/rhel/initiator/add_host.yaml
+++ b/tasks/cloud_vpn/providers/rhel/initiator/add_host.yaml
@@ -7,6 +7,11 @@
     ansible_connection: ssh
     ansible_ssh_private_key_file: "{{ cloud_vpn_initiator_ssh_private_key_file }}"
 
+- name: Get facts
+  setup:
+  delegate_to: initiator
+  delegate_facts: true
+
 - name: Wait for SSH port to be reachable
   wait_for:
     host: "{{ cloud_vpn_initiator_public_ip }}"

--- a/tasks/cloud_vpn/providers/rhel/responder/add_host.yaml
+++ b/tasks/cloud_vpn/providers/rhel/responder/add_host.yaml
@@ -6,6 +6,11 @@
     ansible_user: "{{ cloud_vpn_responder_user }}"
     ansible_ssh_private_key_file: "{{ cloud_vpn_responder_ssh_private_key_file }}"
 
+- name: Get facts
+  setup:
+  delegate_to: responder
+  delegate_facts: true
+
 - name: Wait for SSH port to be reachable
   wait_for:
     host: "{{ cloud_vpn_responder_public_ip }}"


### PR DESCRIPTION
This allows the role to not fail on RHEL8, since yum module
relies on facts to actually detect which Yum version to use (3 vs 4).